### PR TITLE
Fixes #37: 增加返回值

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: check patch
         id: check-patch
-        continue-on-error: true
+        if: ${{ !cancelled() }}
         env:
           FETCH_REF: ${{ inputs.fetch_ref }}
           SRC_REF: ${{ inputs.src_ref }}
@@ -112,6 +112,8 @@ jobs:
           $(cat $patch_dir/checkpatch.log)
           $(echo '```')
           EEE
+
+          exit "${total_error}" # 有错误则步骤失败
           
 
   

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -85,12 +85,11 @@ jobs:
           echo "initramfs_md5sum=$(awk '{print $1}' "${kernel_result_dir}"/*/initramfs.img.md5sum)" >> $GITHUB_OUTPUT
       
       - name: summary
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         id: summary
         env:
           kernel_url: ${{ steps.publish-kernel.outputs.kernel_download_url }}
           upload_dir: ${{ inputs.upload_dir }}
-        continue-on-error: true
         run: |
           if [ "$kernel_url" != "" ]; then
             result="Kernel build succeeded: [${upload_dir}]($(dirname ${kernel_url}))/"
@@ -112,4 +111,6 @@ jobs:
           echo "summary_content<<EOF" >> $GITHUB_OUTPUT
           cat summary >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+          [ "$kernel_url" != "" ] # 设置步骤状态
 

--- a/.github/workflows/kunit-test.yml
+++ b/.github/workflows/kunit-test.yml
@@ -60,7 +60,7 @@ jobs:
       
       - name: run kunit test
         id: run-kunit-test
-        continue-on-error: true
+        if: ${{ !cancelled() }}
         run: |
           cd kernel-src
           make distclean
@@ -87,6 +87,8 @@ jobs:
           $(cat kunit.log)
           $(echo '```')
           EEE
+
+          grep -q 'Testing complete' kunit.log # 设置步骤结果为失败或成功
           
       # - name: after
       #   env:

--- a/.github/workflows/lava-trigger.yml
+++ b/.github/workflows/lava-trigger.yml
@@ -320,6 +320,7 @@ jobs:
           echo "summary_content<<EOF" >> $GITHUB_OUTPUT
           cat summary_content >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+          exit 1
 
 
       - id: summary
@@ -376,3 +377,5 @@ jobs:
           $lava_results
           \`\`\`
           EEE
+
+          [ "${lava_health}" = Complete ]   # 设置步骤结果为失败或成功

--- a/.github/workflows/rvck-actions.yml
+++ b/.github/workflows/rvck-actions.yml
@@ -134,4 +134,17 @@ jobs:
         ${{ needs.check-patch.outputs.summary_content }}
 
         </details>
-    
+  
+  results:
+    needs: [kunit-test, kernel-build, lava-trigger, check-patch, collect-result]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: show final result
+        run: |
+          # 所有需要运行的job都成功则整体成功
+          [ "${{ needs.kunit-test.result }}" != failure ] && \
+          [ "${{ needs.kernel-build.result }}" != failure ] && \
+          [ "${{ needs.lava-trigger.result }}" != failure ] && \
+          [ "${{ needs.check-patch.result }}" != failure ] && \
+          [ "${{ needs.collect-result.result }}" != failure ]


### PR DESCRIPTION
kunit-test,kernel-build等任务由于要收集summary结果，非零返回值被拦截后，没有继续传递返回值

目前改为所有任务结尾增加退出状态返回值
