### PR TITLE
Lava add hardware support

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -36,7 +36,7 @@ jobs:
             rm -rf kernel-src || true
             git init kernel-src
             cd kernel-src
-            set -e
+            set -ex
             git config user.email rvci@isrc.iscas.ac.cn
             git config user.name rvci
             git remote add origin "${REPO}"
@@ -70,7 +70,7 @@ jobs:
           FETCH_REF: ${{ inputs.fetch_ref }}
           SRC_REF: ${{ inputs.src_ref }}
         run: |
-        
+          set -x
           patch_dir=patch-$(date +%Y%m%d%H%M%S)
           cd "kernel-src" 
         
@@ -117,6 +117,7 @@ jobs:
           $(echo '```')
           EEE
 
+          cat summary_content >> $GITHUB_STEP_SUMMARY
           exit "${total_error}" # 有错误则步骤失败
           
 

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -96,17 +96,16 @@ jobs:
           fi
 
           summary_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/#summary-${{ job.check_run_id }}"
-
-          cat > summary << EEE
-          ## Kernel Build Result
-          
-          $result
-          
-          $(cat "${kernel_result_dir}"/*/*.md5sum)
-
-          - detail log: ${summary_url}
-          EEE
-
+          {
+            echo "## Kernel Build Result"
+            echo ""
+            echo "- $result"
+            cat "${kernel_result_dir}"/*/*.md5sum 2>/dev/null | while read -r l; do
+                echo "- $l"
+            done
+            echo ""
+            echo "- detail log: ${summary_url}"
+          } | tee summary
           
           echo "summary_content<<EOF" >> $GITHUB_OUTPUT
           cat summary >> $GITHUB_OUTPUT
@@ -122,5 +121,5 @@ jobs:
           \`\`\`
           EEE
           
-          [ "$kernel_url" != "" ] # 设置步骤状态
+          [ "$kernel_files_url" != "" ] # 设置步骤状态
 

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -17,10 +17,8 @@ on:
         description: '上传目录'
 
     outputs:
-      kernel_download_url:
-        value: ${{ jobs.kernel-build.outputs.kernel_download_url }}
-      initramfs_download_url:
-        value: ${{ jobs.kernel-build.outputs.initramfs_download_url }}
+      kernel_files_url:
+        value: ${{ jobs.kernel-build.outputs.kernel_files_url }}
       kernel_md5sum:
         value: ${{ jobs.kernel-build.outputs.kernel_md5sum }}
       initramfs_md5sum:
@@ -39,8 +37,7 @@ jobs:
       group: kernel_build-runner
             
     outputs:
-      kernel_download_url: ${{ steps.publish-kernel.outputs.kernel_download_url }}
-      initramfs_download_url: ${{ steps.publish-kernel.outputs.initramfs_download_url }}
+      kernel_files_url: ${{ steps.publish-kernel.outputs.kernel_files_url }}
       kernel_md5sum: ${{ steps.publish-kernel.outputs.kernel_md5sum }}
       initramfs_md5sum: ${{ steps.publish-kernel.outputs.initramfs_md5sum }}
       summary_content: ${{ steps.summary.outputs.summary_content }}
@@ -79,20 +76,21 @@ jobs:
         run: |
           
           rsync -av --progress --mkpath "${kernel_result_dir}"/*/* rvck@10.30.190.110::RVCK/${{ inputs.upload_dir }}/
-          echo "kernel_download_url=https://repo.tarsier-infra.isrc.ac.cn/openEuler-RISC-V/RVCK/OERV-RVCI/${{ inputs.upload_dir }}/Image" >> $GITHUB_OUTPUT
+          echo "kernel_files_domain_url=https://repo.tarsier-infra.isrc.ac.cn/openEuler-RISC-V/RVCK/OERV-RVCI/${{ inputs.upload_dir }}" >> $GITHUB_OUTPUT
+          echo "kernel_files_url=http://10.30.190.110/openEuler-RISC-V/RVCK/OERV-RVCI/${{ inputs.upload_dir }}" >> $GITHUB_OUTPUT
           echo "kernel_md5sum=$(awk '{print $1}' "${kernel_result_dir}"/*/Image.md5sum)" >> $GITHUB_OUTPUT
-          echo "initramfs_download_url=https://repo.tarsier-infra.isrc.ac.cn/openEuler-RISC-V/RVCK/OERV-RVCI/${{ inputs.upload_dir }}/initramfs.img" >> $GITHUB_OUTPUT
           echo "initramfs_md5sum=$(awk '{print $1}' "${kernel_result_dir}"/*/initramfs.img.md5sum)" >> $GITHUB_OUTPUT
       
       - name: summary
         if: ${{ !cancelled() }}
         id: summary
         env:
-          kernel_url: ${{ steps.publish-kernel.outputs.kernel_download_url }}
+          kernel_files_domain_url: ${{ steps.publish-kernel.outputs.kernel_files_domain_url }}
+          kernel_files_url: ${{ steps.publish-kernel.outputs.kernel_files_url }}
           upload_dir: ${{ inputs.upload_dir }}
         run: |
-          if [ "$kernel_url" != "" ]; then
-            result="Kernel build succeeded: [${upload_dir}]($(dirname ${kernel_url}))/"
+          if [ "$kernel_files_url" != "" ]; then
+            result="Kernel build succeeded: [${upload_dir}]($kernel_files_domain_url)/"
           else
             result="Kernel build failed."
           fi

--- a/.github/workflows/kunit-test.yml
+++ b/.github/workflows/kunit-test.yml
@@ -61,6 +61,7 @@ jobs:
       - name: run kunit test
         id: run-kunit-test
         if: ${{ !cancelled() }}
+        shell: bash
         run: |
           cd kernel-src
           make distclean
@@ -70,7 +71,7 @@ jobs:
           
           summary_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/#summary-${{ job.check_run_id }}"
 
-          cat >> summary << EEE
+          cat >> summary <<- EEE
           ## Kunit Test Result
           
           $result

--- a/.github/workflows/lava-trigger.yml
+++ b/.github/workflows/lava-trigger.yml
@@ -7,27 +7,23 @@ on:
         value: ${{ jobs.collect-summary.outputs.summary_content }}
 
     inputs:
-      kernel_download_url:
-        description: '内核下载链接'
+      kernel_files_url:
+        description: '内核文件夹链接'
         type: string
         required: true
+
       kernel_md5sum:
         description: '内核md5sum'
         type: string
         required: false
-
-      rootfs_download_url:
-        description: 'rootfs下载链接'
-        required: false
-        type: string
-
-      initramfs_download_url:
-        description: 'initramfs下载链接'
-        required: false
-        type: string
       
       initramfs_md5sum:
         description: 'initramfs md5sum'
+        required: false
+        type: string
+
+      rootfs_download_url:
+        description: 'rootfs下载链接'
         required: false
         type: string
 
@@ -44,30 +40,33 @@ on:
 
       lava_template:
         description: 'lava测试模板'
-        required: true
+        required: false
         type: string
 
       testcase_path:
         description: '需要执行的用例yaml 文件路径'
         required: true
         type: string
-
-      # testcase_params:
-      #   description: '测试用例参数,[key=value ...]'
-      #   type: string
-      #   required: false
+      
+      ltp_testsuite:
+        description: 'ltp 测试类型'
+        required: false
+        type: string
+        default: 'math'
     
     secrets:
       lava_token:
         required: true
 
 env:
+  kernel_files_url: ${{ inputs.kernel_files_url }}
+  kernel_download_url: ${{ inputs.kernel_files_url }}/Image
+  initramfs_download_url: ${{ inputs.kernel_files_url }}/initramfs.img
   testcase_repo: ${{ inputs.testcase_repo }}
   testcase_ref: ${{ inputs.testcase_ref }}
-  kernel_download_url: ${{ inputs.kernel_download_url }}
-  initramfs_download_url: ${{ inputs.initramfs_download_url }}
   lava_template: ${{ inputs.lava_template }}
   testcase_path: ${{ inputs.testcase_path }}
+  ltp_testsuite: ${{ inputs.ltp_testsuite }}
   lava_server: lava.oerv.ac.cn
   lava_admin_token: ${{ secrets.lava_token }}
   
@@ -100,14 +99,21 @@ jobs:
           input_rootfs_download_url: ${{ inputs.rootfs_download_url }}
           input_kernel_md5sum: ${{ inputs.kernel_md5sum }}
           input_initramfs_md5sum: ${{ inputs.initramfs_md5sum }}
+        shell: bash
         run: |
+          set -x
           echo "ssh_port=$(od -An -N2 -i /dev/urandom | awk -v min=10000 -v max=20000 '{print min + ($1 % (max - min + 1))}')" >> $GITHUB_OUTPUT
+          
           repo_name=${github_repo#*/}
           echo "repo_name=$repo_name" >> $GITHUB_OUTPUT
+
           job_name="${github_repo/\//_}_${event_name}_${issue_id:-"$(date +"%Y%m%d")"}_${comment_id:+_$comment_id}"
           echo "job_name=$job_name" >> $GITHUB_OUTPUT
+
           device_type="$(yq -r .device_type "$lava_template")"
+
           echo "testitem_name=${job_name}_$(echo "${testcase_path}" | awk -F'/' '{print $2}')_${device_type}" >> $GITHUB_OUTPUT
+          
           rootfs_download_url="${input_rootfs_download_url}"
           if [ -z "$rootfs_download_url" ]; then
             if [ "$device_type" = qemu ]; then
@@ -116,19 +122,27 @@ jobs:
               rootfs_download_url="https://fast-mirror.isrc.ac.cn/openeuler-sig-riscv/openEuler-RISC-V/RVCK/openEuler24.03-LTS-SP1/openeuler-rootfs.tar.gz"
             fi
           fi
+          echo "rootfs_download_url=$rootfs_download_url" >> $GITHUB_OUTPUT
 
           kernel_md5sum="$input_kernel_md5sum"
           if [ -z "$kernel_md5sum" ]; then
               kernel_md5sum=$(curl "${kernel_download_url}.md5sum" 2>/dev/null | awk '{print $1}' || echo "")
           fi
+          echo "kernel_md5sum=$kernel_md5sum" >> $GITHUB_OUTPUT
+
           initramfs_md5sum="$input_initramfs_md5sum"
           if [ -z "$initramfs_md5sum" ]; then
               initramfs_md5sum=$(curl "${initramfs_download_url}.md5sum" 2>/dev/null | awk '{print $1}' || echo "")
           fi
-
-          echo "rootfs_download_url=$rootfs_download_url" >> $GITHUB_OUTPUT
-          echo "kernel_md5sum=$kernel_md5sum" >> $GITHUB_OUTPUT
           echo "initramfs_md5sum=$initramfs_md5sum" >> $GITHUB_OUTPUT
+          
+          declare -A dtb_map=(
+            ["sg2042"]="${kernel_files_url}/lib/dtbs/sophgo/mango-milkv-pioneer.dtb"
+            ["spacemit-k1-bananapi-f3"]="${kernel_files_url}/lib/dtbs/spacemit/k1-bananapi-f3.dtb"
+            ["lpi4a"]="${kernel_files_url}/lib/dtbs/thead/th1520-lichee-pi-4a.dtb"
+            ["qemu"]=""
+          )
+          echo "dtb_url=${dtb_map[${device_type}]:-"UNKNOWN_DEVICE_TYPE"}" >> $GITHUB_OUTPUT
 
       - name: setup_lava_template
         shell: python3 {0}
@@ -137,6 +151,9 @@ jobs:
           job_name: ${{ steps.gen_var.outputs.job_name }}
           testitem_name: ${{ steps.gen_var.outputs.testitem_name }}
           rootfs_download_url: ${{ steps.gen_var.outputs.rootfs_download_url }}
+          kernel_md5sum: ${{ steps.gen_var.outputs.kernel_md5sum }}
+          initramfs_md5sum: ${{ steps.gen_var.outputs.initramfs_md5sum }}
+          dtb_url: ${{ steps.gen_var.outputs.dtb_url }}
           repo_name: ${{ steps.gen_var.outputs.repo_name }}
         run: |
           import yaml
@@ -152,6 +169,8 @@ jobs:
 
           testcase_path = os.getenv("testcase_path")
           assert testcase_path, "Testcase URL is not set"
+
+          ltp_testsuite = os.getenv("ltp_testsuite", "")
 
           job_name = os.getenv("job_name")
           assert job_name, "Job name is not set"
@@ -174,9 +193,12 @@ jobs:
           assert repo_name, "repo name is not set"
 
           initramfs_download_url = os.getenv("initramfs_download_url")
-          assert initramfs_download_url, "Initramfs download URL is not set"
+          assert initramfs_download_url, "initramfs download URL is not set"
 
-          initramfs_md5sum = os.getenv("initramfs_md5sum")
+          initramfs_md5sum = os.getenv("initramfs_md5sum", "")
+          
+          # 硬件设备需要dtb
+          dtb_url = os.getenv("dtb_url", "")
 
           content = open(lava_template, "r").read()\
                     .replace("${job_name}", job_name)\
@@ -184,29 +206,57 @@ jobs:
                     .replace("${rootfs_image_url}", rootfs_download_url)\
                     .replace("${testcase_repo}", f"https://github.com/{testcase_repo}.git")\
                     .replace("${testitem_name}", testitem_name)\
-                    .replace("${testcase_path}", testcase_path)
+                    .replace("${testcase_path}", testcase_path)\
+                    .replace("${ltp_testsuite}", ltp_testsuite)\
+                    .replace("${dtb_url}", dtb_url)\
+                    .replace("${ramdisk_url}", initramfs_download_url)
 
           data = yaml.safe_load(content)
 
           # qemu 需要设置ssh port
           if data['device_type'] == 'qemu' and 'context' in data and 'extra_options' in data['context']:
               data['context']['extra_options'] = [i.replace('hostfwd=tcp::10001-:22', f'hostfwd=tcp::{ssh_port}-:22') for i in list(data['context']['extra_options'])]
+          
+          def get_action_by_name(name):
+              for action in data['actions']:
+                  if name in action:
+                      return action[name]
+              return None
+          
+          deploy_action = get_action_by_name('deploy')
 
           # add kernel md5sum
           if kernel_md5sum:
-              data['actions'][0]['deploy']['images']['kernel']['md5sum'] = kernel_md5sum
+              if data['device_type'] == 'qemu':
+                  deploy_action['images']['kernel']['md5sum'] = kernel_md5sum
+              else:
+                  deploy_action['kernel']['md5sum'] = kernel_md5sum
 
           # rvck 需要initramfs
           if repo_name == "rvck":
               data['context']['extra_options'] = [i.replace('root=/dev/vda', 'root=/dev/vdb') for i in list(data['context']['extra_options'])]
-              data['actions'][0]['deploy']['images']['initrd'] = {'image_arg': '-initrd {initrd}', 'url': initramfs_download_url}
+              if data['device_type'] == 'qemu':
+                  deploy_action['images']['initrd'] = {'image_arg': '-initrd {initrd}', 'url': initramfs_download_url}
+              else:
+                  deploy_action['initrd'] = {'image_arg': '-initrd {initrd}', 'url': initramfs_download_url}
+
               if initramfs_md5sum:
-                  data['actions'][0]['deploy']['images']['initrd']['md5sum'] = initramfs_md5sum
+                  if data['device_type'] == 'qemu':
+                      deploy_action['images']['initrd']['md5sum'] = initramfs_md5sum
+                  else:
+                      deploy_action['initrd']['md5sum'] = initramfs_md5sum
 
+          test_action = get_action_by_name('test')
           if len(testcase_ref):
-              data['actions'][2]['test']['definitions'][0]['revision'] = testcase_ref
+              test_action['definitions'][0]['revision'] = testcase_ref
 
-          data['actions'][2]['test']['definitions'][0].pop('parameters', None)
+          params = test_action['definitions'][0].pop('parameters', {})
+          for k in list(params.keys()):
+              if params[k].startswith("${"):
+                  params.pop(k)
+          if params:
+              test_action['definitions'][0]['parameters'] = params
+          
 
           with open(lava_template, 'w') as f:
               f.write(yaml.dump(data, sort_keys=False))

--- a/.github/workflows/lava-trigger.yml
+++ b/.github/workflows/lava-trigger.yml
@@ -76,6 +76,7 @@ jobs:
       lava_jobid: ${{ steps.run_lava_check.outputs.lava_jobid }}
       testitem_name: ${{ steps.gen_var.outputs.testitem_name }}
       rootfs_download_url: ${{ steps.gen_var.outputs.rootfs_download_url }}
+      device_type: ${{ steps.gen_var.outputs.device_type }}
     runs-on: 'ubuntu-latest'
 
     steps:
@@ -111,6 +112,7 @@ jobs:
           echo "job_name=$job_name" >> $GITHUB_OUTPUT
 
           device_type="$(yq -r .device_type "$lava_template")"
+          echo "device_type=$device_type" >> $GITHUB_OUTPUT
 
           echo "testitem_name=${job_name}_$(echo "${testcase_path}" | awk -F'/' '{print $2}')_${device_type}" >> $GITHUB_OUTPUT
           
@@ -365,6 +367,7 @@ jobs:
       lava_jobid: ${{ needs.lava-trigger.outputs.lava_jobid }}
       testitem_name: ${{ needs.lava-trigger.outputs.testitem_name }}
       rootfs_download_url: ${{ needs.lava-trigger.outputs.rootfs_download_url }}
+      lava_device_type: ${{ needs.lava-trigger.outputs.device_type }}
     steps:
       - name: install depends
         run: |
@@ -429,18 +432,18 @@ jobs:
           summary_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/#summary-${{ job.check_run_id }}"
 
           cat > summary << EEE
-          ## LAVA Check
+          ## LAVA Check ($lava_device_type)
 
            | args | value |
            |:-:|:-:|
            | testcase_repo | ${testcase_repo} |
-           | testcase_ref | ${testcase_ref} |
            | lava_template | ${lava_template} |
            | testcase_path | ${testcase_path} |
-           | testitem_name | ${testitem_name} |
            | kernel_download_url | ${kernel_download_url} |
            | initramfs_download_url | ${initramfs_download_url} |
            | rootfs_download_url | ${rootfs_download_url} |
+           | testcase_ref | ${testcase_ref} |
+           | testitem_name | ${testitem_name} |
           
           ### result: $(if [ "${lava_health}" = Complete ]; then echo "Lava check done!"; else echo "Lava check fail!"; fi)
           

--- a/.github/workflows/parse-rvck.yml
+++ b/.github/workflows/parse-rvck.yml
@@ -37,12 +37,27 @@ on:
       testcase_repo:
         description: lava 仓库地址
         value: ${{ jobs.parse-request.outputs.testcase_repo }}
-      lava_template:
-        description: lava测试模板
-        value: ${{ jobs.parse-request.outputs.lava_template }}
       testcase_path:
         description: lava 需要执行的用例yaml 文件路径
         value: ${{ jobs.parse-request.outputs.testcase_path }}
+      lava_hardware:
+        description: 需要执行lava的硬件
+        value: ${{ jobs.parse-request.outputs.lava_hardware }}
+      ltp_testsuite:
+        description: ltp 测试类型
+        value: ${{ jobs.parse-request.outputs.ltp_testsuite }}
+      lava_template_qemu:
+        description: lava qemu 测试模板
+        value: ${{ jobs.parse-request.outputs.lava_template_qemu }}
+      lava_template_sg2042:
+        description: lava sg2042 测试模板
+        value: ${{ jobs.parse-request.outputs.lava_template_sg2042 }}
+      lava_template_k1:
+        description: lava k1 测试模板
+        value: ${{ jobs.parse-request.outputs.lava_template_k1 }}
+      lava_template_lpi4a:
+        description: lava lpi4a 测试模板
+        value: ${{ jobs.parse-request.outputs.lava_template_lpi4a }}
 
    
 jobs:
@@ -56,8 +71,13 @@ jobs:
       COMMIT_URL: ${{ steps.parse-request.outputs.COMMIT_URL }}
       NEED_RUN_JOB: ${{ steps.parse-request.outputs.NEED_RUN_JOB }}
       testcase_repo: ${{ steps.parse-request.outputs.testcase_repo }}
-      lava_template: ${{ steps.parse-request.outputs.lava_template }}
+      lava_template_qemu: ${{ steps.parse-request.outputs.lava_template_qemu }}
+      lava_template_sg2042: ${{ steps.parse-request.outputs.lava_template_sg2042 }}
+      lava_template_k1: ${{ steps.parse-request.outputs.lava_template_k1 }}
+      lava_template_lpi4a: ${{ steps.parse-request.outputs.lava_template_lpi4a }}
       testcase_path: ${{ steps.parse-request.outputs.testcase_path }}
+      lava_hardware: ${{ steps.parse-request.outputs.lava_hardware }}
+      ltp_testsuite: ${{ steps.parse-request.outputs.ltp_testsuite }}
     env:
       GH_TOKEN: ${{ github.token }}
       x_github_event: ${{ inputs.x_github_event }}
@@ -80,7 +100,12 @@ jobs:
 
           import json
           import os
-
+          
+          DEFAULT_testcase_path = "lava-testcases/common-test/ltp/ltp.yaml"
+          
+          lava_hardware_testcase_map = ${{ vars.RVCKCI_DEFAULT_CASE }}
+          
+          DEFAULT_lava_hardware = ${{ vars.RAVA_SUPPORT_DEVICE }}
 
           def write_properties_file(info: dict):
               for k, v in info.items():
@@ -106,7 +131,7 @@ jobs:
                       str(i).split('=',maxsplit=1)
                   for i in shlex.split(comment.strip()[6:])]
               }
-              for k in ['lava_template','testcase_path', 'fetch', 'job']:
+              for k in ['lava_hardware', 'testcase_path', 'fetch', 'job', 'ltp_testsuite']:
                   if k in data:
                       res[k] = data.pop(k)
 
@@ -150,6 +175,18 @@ jobs:
                   res["FETCH_REF"] = res.pop("fetch")
                   res["COMMIT_URL"] = f'{payload["repository"]["html_url"]}/commit/{res["FETCH_REF"]}'
               
+              ## lava info
+              res.setdefault("testcase_path", DEFAULT_testcase_path)
+              if "lava_hardware" in res:
+                  res["lava_hardware"] = [i.strip() for i in res["lava_hardware"].split(",") if i.strip()]
+              if 'lava_hardware' not in res or not res["lava_hardware"]:
+                  res["lava_hardware"] = DEFAULT_lava_hardware
+              for hardware in res["lava_hardware"]:
+                  if hardware not in DEFAULT_lava_hardware:
+                      print(f"lava hardware {hardware} not in default support list, ignore")
+                      continue
+                  res[f"lava_template_{hardware}"] = lava_hardware_testcase_map.get(hardware, {}).get(res['testcase_path'], '')
+
               write_properties_file(res)
 
 
@@ -223,16 +260,13 @@ jobs:
           echo "COMMIT_URL=$(cat COMMIT_URL)" >> $GITHUB_OUTPUT
           echo "NEED_RUN_JOB=$(cat job || echo 'kunit-test,kernel-build,check-patch,lava-trigger')" >> $GITHUB_OUTPUT
           echo "testcase_repo=$(cat testcase_repo || echo 'RVCK-Project/lavaci')" >> $GITHUB_OUTPUT
-          echo "lava_template=$(cat lava_template || echo 'lava-job-template/qemu/qemu-ltp.yaml')" >> $GITHUB_OUTPUT
-          echo "testcase_path=$(cat testcase_path || echo 'lava-testcases/common-test/ltp/ltp.yaml')" >> $GITHUB_OUTPUT
+          echo "lava_hardware=$(cat lava_hardware || echo '')" >> $GITHUB_OUTPUT
+          for f in lava_template_*; do
+                [ ! -f "$f" ] && continue
+                echo "$f=$(cat "$f")" >> $GITHUB_OUTPUT
+          done
 
-          echo "REPO=$(cat REPO)" >> $GITHUB_ENV
-          echo "FETCH_REF=$(cat FETCH_REF)" >> $GITHUB_ENV
-          echo "SRC_REF=$(cat SRC_REF)" >> $GITHUB_ENV
-          echo "ISSUE_ID=$(cat ISSUE_ID)" >> $GITHUB_ENV
-          echo "NEED_RUN_JOB=$(cat job || echo 'kunit-test,kernel-build,check-patch,lava-trigger')" >> $GITHUB_ENV
-          echo "testcase_repo=$(cat testcase_repo || echo 'https://github.com/RVCK-Project/lavaci.git')" >> $GITHUB_ENV
-          echo "lava_template=$(cat lava_template || echo 'lava-job-template/qemu/qemu-ltp.yaml')" >> $GITHUB_ENV
-          echo "testcase_path=$(cat testcase_path || echo 'lava-testcases/common-test/ltp/ltp.yaml')" >> $GITHUB_ENV
+          echo "testcase_path=$(cat testcase_path || echo '')" >> $GITHUB_OUTPUT
+          echo "ltp_testsuite=$(cat ltp_testsuite || echo 'math')" >> $GITHUB_OUTPUT
           
 

--- a/.github/workflows/rava-actions.yml
+++ b/.github/workflows/rava-actions.yml
@@ -148,7 +148,7 @@ jobs:
     secrets:
       lava_token: ${{ secrets.lava_token }}
     with:
-      kernel_download_url: 'https://fast-mirror.isrc.ac.cn/openeuler-sig-riscv/openEuler-RISC-V/RVCK/OERV-RVCI/rvck-olk/latest/Image'
+      kernel_files_url: 'https://fast-mirror.isrc.ac.cn/openeuler-sig-riscv/openEuler-RISC-V/RVCK/OERV-RVCI/rvck-olk/latest'
       testcase_repo: ${{ needs.parse-request.outputs.testcase_repo }}
       testcase_ref: ${{ needs.parse-request.outputs.testcase_ref }}
       lava_template: ${{ needs.parse-request.outputs.lava_template }}

--- a/.github/workflows/rvck-actions.yml
+++ b/.github/workflows/rvck-actions.yml
@@ -44,8 +44,8 @@ jobs:
         | head ref | ${{ needs.parse-request.outputs.FETCH_REF }} |
         | base ref | ${{ needs.parse-request.outputs.SRC_REF }} |
         |LAVA repo | ${{ needs.parse-request.outputs.testcase_repo }} |
-        |LAVA Template | ${{ needs.parse-request.outputs.lava_template }} |
-        |Testcase path | ${{ needs.parse-request.outputs.testcase_path }} |
+        |LAVA hardware | ${{ needs.parse-request.outputs.lava_hardware }} |
+        |LAVA Testcase path | ${{ needs.parse-request.outputs.testcase_path }} |
         |need run job | ${{ needs.parse-request.outputs.NEED_RUN_JOB }} |
 
         </details>
@@ -72,20 +72,65 @@ jobs:
       rync_passphrase: ${{ secrets.RSYNC_PASSPHRASE }}
 
       
-  lava-trigger:
+  lava-trigger-qemu:
     needs: [parse-request, kernel-build]
+    if: ${{ needs.parse-request.outputs.lava_template_qemu }}
     uses: ./.github/workflows/lava-trigger.yml
-    if: ${{ contains(needs.parse-request.outputs.NEED_RUN_JOB, 'lava-trigger') }}
     secrets: 
       lava_token: ${{ secrets.LAVA_TOKEN }}
     with:
       testcase_repo: ${{ needs.parse-request.outputs.testcase_repo }}
-      lava_template: ${{ needs.parse-request.outputs.lava_template }}
+      lava_template: ${{ needs.parse-request.outputs.lava_template_qemu }}
       testcase_path: ${{ needs.parse-request.outputs.testcase_path }}
-      kernel_download_url: ${{ needs.kernel-build.outputs.kernel_download_url }}
-      initramfs_download_url: ${{ needs.kernel-build.outputs.initramfs_download_url }}
+      kernel_files_url: ${{ needs.kernel-build.outputs.kernel_files_url }}
       kernel_md5sum: ${{ needs.kernel_build.outputs.kernel_md5sum }}
       initramfs_md5sum: ${{ needs.kernel_build.outputs.initramfs_md5sum }}
+      ltp_testsuite: ${{ needs.parse-request.outputs.ltp_testsuite }}
+
+  lava-trigger-sg2042:
+    needs: [parse-request, kernel-build]
+    if: ${{ needs.parse-request.outputs.lava_template_sg2042 }}
+    uses: ./.github/workflows/lava-trigger.yml
+    secrets: 
+      lava_token: ${{ secrets.LAVA_TOKEN }}
+    with:
+      testcase_repo: ${{ needs.parse-request.outputs.testcase_repo }}
+      lava_template: ${{ needs.parse-request.outputs.lava_template_sg2042 }}
+      testcase_path: ${{ needs.parse-request.outputs.testcase_path }}
+      kernel_files_url: ${{ needs.kernel-build.outputs.kernel_files_url }}
+      kernel_md5sum: ${{ needs.kernel_build.outputs.kernel_md5sum }}
+      initramfs_md5sum: ${{ needs.kernel_build.outputs.initramfs_md5sum }}
+      ltp_testsuite: ${{ needs.parse-request.outputs.ltp_testsuite }}
+  
+  lava-trigger-k1:
+    needs: [parse-request, kernel-build]
+    if: ${{ needs.parse-request.outputs.lava_template_k1 }}
+    uses: ./.github/workflows/lava-trigger.yml
+    secrets: 
+      lava_token: ${{ secrets.LAVA_TOKEN }}
+    with:
+      testcase_repo: ${{ needs.parse-request.outputs.testcase_repo }}
+      lava_template: ${{ needs.parse-request.outputs.lava_template_k1 }}
+      testcase_path: ${{ needs.parse-request.outputs.testcase_path }}
+      kernel_files_url: ${{ needs.kernel-build.outputs.kernel_files_url }}
+      kernel_md5sum: ${{ needs.kernel_build.outputs.kernel_md5sum }}
+      initramfs_md5sum: ${{ needs.kernel_build.outputs.initramfs_md5sum }}
+      ltp_testsuite: ${{ needs.parse-request.outputs.ltp_testsuite }}
+
+  lava-trigger-lpi4a:
+    needs: [parse-request, kernel-build]
+    if: ${{ needs.parse-request.outputs.lava_template_lpi4a }}
+    uses: ./.github/workflows/lava-trigger.yml
+    secrets: 
+      lava_token: ${{ secrets.LAVA_TOKEN }}
+    with:
+      testcase_repo: ${{ needs.parse-request.outputs.testcase_repo }}
+      lava_template: ${{ needs.parse-request.outputs.lava_template_lpi4a }}
+      testcase_path: ${{ needs.parse-request.outputs.testcase_path }}
+      kernel_files_url: ${{ needs.kernel-build.outputs.kernel_files_url }}
+      kernel_md5sum: ${{ needs.kernel_build.outputs.kernel_md5sum }}
+      initramfs_md5sum: ${{ needs.kernel_build.outputs.initramfs_md5sum }}
+      ltp_testsuite: ${{ needs.parse-request.outputs.ltp_testsuite }}
 
   check-patch:
     needs: [parse-request]
@@ -99,7 +144,7 @@ jobs:
   
   collect-result:
     if: ${{ !cancelled() && needs.parse-request.outputs.REPO }}
-    needs: [parse-request, pre-check, kunit-test, kernel-build, lava-trigger, check-patch]
+    needs: [parse-request, pre-check, kunit-test, kernel-build, lava-trigger-qemu, lava-trigger-sg2042, lava-trigger-k1, lava-trigger-lpi4a, check-patch]
     permissions:
       issues: write
       pull-requests: write
@@ -112,31 +157,37 @@ jobs:
       event_id: ${{ needs.pre-check.outputs.event_id }}
       append_content: |
         **测试完成**
-        <details>
-        
+        <details>  
         <summary> 详细结果:</summary>
         
-        # RVCK result
-
         | check | result |
         | :-: | :-: |
         |kunit-test| ${{ needs.kunit-test.result }} |
         |kernel-build| ${{ needs.kernel-build.result }} |
-        |lava-trigger| ${{ needs.lava-trigger.result }} |
         |check-patch| ${{ needs.check-patch.result }} |
+        |lava-trigger-qemu| ${{ needs.lava-trigger-qemu.result }} |
+        |lava-trigger-sg2042| ${{ needs.lava-trigger-sg2042.result }} |
+        |lava-trigger-k1 | ${{ needs.lava-trigger-k1.result }} |
+        | lava-trigger-lpi4a | ${{ needs.lava-trigger-lpi4a.result }} |
         
         ${{ needs.kunit-test.outputs.summary_content }}
         
         ${{ needs.kernel-build.outputs.summary_content }}
 
-        ${{ needs.lava-trigger.outputs.summary_content }}
-        
         ${{ needs.check-patch.outputs.summary_content }}
+
+        ${{ needs.lava-trigger-qemu.outputs.summary_content }}
+
+        ${{ needs.lava-trigger-sg2042.outputs.summary_content }}
+
+        ${{ needs.lava-trigger-k1.outputs.summary_content }}
+
+        ${{ needs.lava-trigger-lpi4a.outputs.summary_content }}
 
         </details>
   
   results:
-    needs: [kunit-test, kernel-build, lava-trigger, check-patch, collect-result]
+    needs: [kunit-test, kernel-build, lava-trigger-qemu, lava-trigger-sg2042, lava-trigger-k1, lava-trigger-lpi4a, check-patch, collect-result]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
@@ -145,6 +196,9 @@ jobs:
           # 所有需要运行的job都成功则整体成功
           [ "${{ needs.kunit-test.result }}" != failure ] && \
           [ "${{ needs.kernel-build.result }}" != failure ] && \
-          [ "${{ needs.lava-trigger.result }}" != failure ] && \
           [ "${{ needs.check-patch.result }}" != failure ] && \
-          [ "${{ needs.collect-result.result }}" != failure ]
+          [ "${{ needs.collect-result.result }}" != failure ] && \
+          [ "${{ needs.lava-trigger-qemu.result }}" != failure ] && \
+          [ "${{ needs.lava-trigger-sg2042.result }}" != failure ] && \
+          [ "${{ needs.lava-trigger-k1.result }}" != failure ] && \
+          [ "${{ needs.lava-trigger-lpi4a.result }}" != failure ]

--- a/.github/workflows/update-status.yml
+++ b/.github/workflows/update-status.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: show-info
         run: |
-          cat > $GITHUB_STEP_SUMMARY << EEE
+          cat << EEE
           | input | value |
           |:-:|:-:|
           |repo| $GH_REPO |


### PR DESCRIPTION
- lava 增加新硬件设备支持 #40 
- rvck 默认同时触发 sg2042、th1520、k1、qemu 的lava测试 #38 
- lava-trigger 增加了参数 ltp_testsuite用来接收ltp测试类型，默认为math
- pr|issue中/check 指令支持ltp_testsuite参数
- 优化结果和日志打印，summary链接在运行时不好推算。目前先在关键步骤增加set -x,  以及在最终的评论结果中增加日志。默认折叠。 #32 