### PR TITLE
fix #52: check-patch 日志过大问题， 以及pr触发时默认值问题

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -111,13 +111,15 @@ jobs:
           $(cat summary_content)
           
           $(echo '```log')
-          $(cat $patch_dir/checkpatch.log)
+          error:
+          $(grep -cE "ERROR" "$patch_dir/checkpatch.log")
+          warning:
+          $(grep -cE "WARNING" "$patch_dir/checkpatch.log")
           ---
           $(cat check-patch-result)
           $(echo '```')
           EEE
 
-          cat summary_content >> $GITHUB_STEP_SUMMARY
           exit "${total_error}" # 有错误则步骤失败
           
 

--- a/.github/workflows/parse-rvck.yml
+++ b/.github/workflows/parse-rvck.yml
@@ -131,6 +131,9 @@ jobs:
               """解析comment内容, /check"""
 
               if not comment.strip().startswith("/check"):
+                  if is_pr:
+                      return set_lava_default_value({})
+                  
                   print(comment.strip(), "| not found /check, ignore")
                   return None
               


### PR DESCRIPTION
日志过大会超过 github_summary缓冲区，导致报错
优化策略为 只展示error和warning 关键行